### PR TITLE
Mesh closest point

### DIFF
--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -619,11 +619,13 @@ namespace GShark.Geometry
             MeshVertex CloserVertex = meshVertices[verticesPoints.IndexOf(CloserPointVertex)];
 
             // Finds adjiacent faces to the closer vertex
-            System.Collections.Generic.IEnumerable<MeshFace> AdjacentFaces = CloserVertex.AdjacentFaces();
+            //System.Collections.Generic.IEnumerable<MeshFace> AdjacentFaces = CloserVertex.AdjacentFaces();
+            //All faces check 
+            System.Collections.Generic.IEnumerable<MeshFace> AllFaces = this.Faces;
 
             var CloserPointToFace_List = new List<Point3>();
 
-            foreach (MeshFace face in AdjacentFaces)
+            foreach (MeshFace face in AllFaces)
             {
                 // Retrives the Vertices associated with each face
                 List<MeshVertex> GSVertices = face.AdjacentVertices();

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -607,6 +607,7 @@ namespace GShark.Geometry
             return point.CloudClosestPoint(edgesClosestPoints);
         }
 
+
         public Point3 ClosestPoint(Point3 point)
         {
             // Gets vertices and converts them from type "MeshVertex" to "Point3"
@@ -657,7 +658,8 @@ namespace GShark.Geometry
                 }
                 else 
                 {
-                    throw new Exception("Ngon detected");
+                    //throw new Exception("Ngon detected");
+                    
                 }
             }
             Point3 MeshClosestPoint = point.CloudClosestPoint(CloserPointToFace_List);

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -607,31 +607,10 @@ namespace GShark.Geometry
             return point.CloudClosestPoint(edgesClosestPoints);
         }
 
-        /* Function to find mid point from cloud 
-        private Point3 midPoint(List<Point3> points)
-        {
-            Point3 pointTotSum = Point3.Origin;
-            for (int i = 0; i < points.Count(); i++)
-            {
-                pointTotSum += points[i];
-            }
-            Point3 mid = pointTotSum / points.Count();
-            return mid;
-        }*/
-
         public Point3 ClosestPoint(Point3 point)
         {
-            // Gets vertices and converts them from type "MeshVertex" to "Point3"
             List<MeshVertex> meshVertices = Vertices;
-            //List<Point3> verticesPoints = meshVertices.ConvertAll(v => (Point3)v);
 
-            // Finds closer vertex to the target point
-            //Point3 CloserPointVertex = point.CloudClosestPoint(meshVertices);
-            // Finds the equivalent point as a type "MeshVertex" using the index of the Point3 in its equivalent list
-            //MeshVertex CloserVertex = meshVertices[meshVertices.IndexOf(CloserPointVertex)];
-
-            // Finds adjiacent faces to the closer vertex
-            //System.Collections.Generic.IEnumerable<MeshFace> AdjacentFaces = CloserVertex.AdjacentFaces();
             //All faces check 
             System.Collections.Generic.IEnumerable<MeshFace> AllFaces = this.Faces;
 
@@ -670,7 +649,7 @@ namespace GShark.Geometry
                 else 
                 {
                     //throw new Exception("Ngon detected");
-                    //Stellate method (from Ngon to triangles) 
+                    // Stellate method (from Ngon to triangles) 
                     List<Point3> GSVerticesPoints = GSVertices.ConvertAll(v => (Point3)v);
                     Point3 ngonCentre = Point3.AveragePoint(GSVerticesPoints);
 
@@ -678,15 +657,7 @@ namespace GShark.Geometry
 
                     for (int i = 0; i < GSVertices.Count; i++)
                     {
-                        Point3[] trianglePoints;
-                        if (i== GSVertices.Count - 1)
-                        {
-                            trianglePoints = new Point3[] { ngonCentre, GSVertices[i], GSVertices[0] };
-                        }
-                        else
-                        {
-                            trianglePoints = new Point3[] { ngonCentre, GSVertices[i], GSVertices[i + 1] };
-                        }
+                        Point3[] trianglePoints = new Point3[] { ngonCentre, GSVertices[i], GSVertices[(i + 1)% GSVertices.Count] };
                         Point3 ClosestPointToNgon = ClosestPointToTriangle(trianglePoints, point);
                         TrianglesCP.Add(ClosestPointToNgon);
                     }

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -658,6 +658,8 @@ namespace GShark.Geometry
                 else 
                 {
                     throw new Exception("Ngon detected");
+                    // using Rhino as the checking tool the code path will never end up here because Rhino considers Ngons are a collection of triangles and quads 
+                    //trying to keep the definition of Ngon will crash the "Rhino mesh > G Shark mesh method" in the RhinoCommand code
                 }
             }
             Point3 MeshClosestPoint = point.CloudClosestPoint(CloserPointToFace_List);

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -607,7 +607,7 @@ namespace GShark.Geometry
             return point.CloudClosestPoint(edgesClosestPoints);
         }
 
-        // Function to find mid point from cloud 
+        /* Function to find mid point from cloud 
         private Point3 midPoint(List<Point3> points)
         {
             Point3 pointTotSum = Point3.Origin;
@@ -617,7 +617,7 @@ namespace GShark.Geometry
             }
             Point3 mid = pointTotSum / points.Count();
             return mid;
-        }
+        }*/
 
         public Point3 ClosestPoint(Point3 point)
         {
@@ -672,7 +672,7 @@ namespace GShark.Geometry
                     //throw new Exception("Ngon detected");
                     //Stellate method (from Ngon to triangles) 
                     List<Point3> GSVerticesPoints = GSVertices.ConvertAll(v => (Point3)v);
-                    Point3 ngonCentre = midPoint(GSVerticesPoints);
+                    Point3 ngonCentre = Point3.AveragePoint(GSVerticesPoints);
 
                     var TrianglesCP = new List<Point3>();
 

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -547,6 +547,10 @@ namespace GShark.Geometry
             return data;
         }
 
+        public static string MeshClosestPointTest ()
+        {
+            return "Hello world from Mesh Closest Point";
+        }
 
         /// <summary>
         ///     Type of mesh (Triangular, Quad, Ngon or Error).

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -654,7 +654,7 @@ namespace GShark.Geometry
                     Point3 ClosestPoint0 = ClosestPointToTriangle(trianglePoints, point);
                     CloserPointToFace_List.Add(ClosestPoint0);
                 }
-                else
+                if (GSVertices.Count == 4)
                 {
                     var trianglePoints1 = new List<Point3>() { FacePoints[0], FacePoints[1], FacePoints[2] };
                     var trianglePoints2 = new List<Point3>() { FacePoints[1], FacePoints[2], FacePoints[3] };
@@ -670,6 +670,10 @@ namespace GShark.Geometry
                     Point3 ClosestPoint = point.CloudClosestPoint(TrianglesCP);
 
                     CloserPointToFace_List.Add(ClosestPoint);
+                }
+                else 
+                {
+                    Point3 ClosestPoint = point.CloudClosestPoint(FacePoints);
                 }
             }
             Point3 MeshClosestPoint = point.CloudClosestPoint(CloserPointToFace_List);

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -547,12 +547,18 @@ namespace GShark.Geometry
             return data;
         }
 
-
-        
-
-        // Checks if point is in or out a triangle (boolean result, In - True , Out - False)
+        /// <summary>
+        /// Checks if point is in or out a triangle
+        /// </summary>
+        /// <param name="projection">Point to check.</param>
+        /// <param name="trianglePoints">Triangle vertices.</param>
+        /// <returns> boolean result (In - True , Out - False) </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when trianglePoints is not 3 points.</exception>
         private bool IsPointInTriangle(Point3 projection, Point3[] trianglePoints)
         {
+            if (trianglePoints.Length != 3)
+                throw new ArgumentOutOfRangeException($"{nameof(trianglePoints)} must be 3.");
+
             //edges vectors of the triangle
             Vector3 v0 = new Vector3(trianglePoints[1] - trianglePoints[0]);
             Vector3 v1 = new Vector3(trianglePoints[2] - trianglePoints[1]);
@@ -577,8 +583,15 @@ namespace GShark.Geometry
 
             return ((dotProducts[0] > 0) && (dotProducts[1] > 0) && (dotProducts[2] > 0));
             }
-         
-        // Function that finds the closest point to a triangle (given the 3 vertices as points)
+
+
+        /// <summary>
+        /// Finds the closest point to a triangle
+        /// </summary>
+        /// <param name="trianglePoints">Triangle vertices.</param>
+        /// <param name="point">Test point.</param>
+        /// <returns>Closest point to the triangle.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when trianglePoints is not 3 points.</exception>
         private Point3 ClosestPointToTriangle(Point3[] trianglePoints, Point3 point)
         {
             if (trianglePoints.Length != 3)
@@ -591,13 +604,13 @@ namespace GShark.Geometry
             // if the projection of the point is inside the triangle, we return the closest point
             if (IsPointInTriangle(closestPoint, trianglePoints))
                 return closestPoint;
-
+             
             // If not, we create a line for each triangle edges
             // and then find the closest point on each edge
-            Line segment_AB = new Line(trianglePoints[0], trianglePoints[1]);
-            Line segment_BC = new Line(trianglePoints[1], trianglePoints[2]);
-            Line segment_CA = new Line(trianglePoints[2], trianglePoints[0]);
-            List<Line> segments = new List<Line>() { segment_AB, segment_BC, segment_CA };
+            Line segmentAB = new Line(trianglePoints[0], trianglePoints[1]);
+            Line segmentBC = new Line(trianglePoints[1], trianglePoints[2]);
+            Line segmentCA = new Line(trianglePoints[2], trianglePoints[0]);
+            List<Line> segments = new List<Line>() { segmentAB, segmentBC, segmentCA };
             List<Point3> edgesClosestPoints = new List<Point3>();
             foreach (Line segment in segments)
             {
@@ -607,64 +620,48 @@ namespace GShark.Geometry
             return Point3.CloudClosestPoint(edgesClosestPoints, point);
         }
 
+        /// <summary>
+        /// Finds the closest point to a mesh.
+        /// </summary>
+        /// <param name="point">Test point.</param>
+        /// <returns>Mesh Closest Point.</returns>
+        /// <exception>Method does not work with concave Ngons.</exception>
         public Point3 ClosestPoint(Point3 point)
         {
             List<MeshVertex> meshVertices = Vertices;
-
             // All faces check 
-            System.Collections.Generic.IEnumerable<MeshFace> AllFaces = this.Faces;
+            IEnumerable<MeshFace> allFaces = this.Faces;
+            var closerPointToFaceList = new List<Point3>();
 
-            var CloserPointToFace_List = new List<Point3>();
-
-            foreach (MeshFace face in AllFaces)
+            foreach (MeshFace face in allFaces)
             {
                 // Retrives the Vertices associated with each face
                 List<MeshVertex> faceVertices = face.AdjacentVertices();
-                // Converts from MeshVertex to Point3
-                //List<Point3> faceVertices  = faceVertices .ConvertAll(v => (Point3)v);
-
-                if (faceVertices .Count == 3)
+                
+                if (faceVertices.Count == 3)
                 {
-                    var trianglePoints = new Point3[] { faceVertices [0], faceVertices [1], faceVertices [2] };
-                    Point3 ClosestPoint0 = ClosestPointToTriangle(trianglePoints, point);
-                    CloserPointToFace_List.Add(ClosestPoint0);
+                    var trianglePoints = new Point3[] { faceVertices[0], faceVertices[1], faceVertices[2] };
+                    Point3 closestPoint0 = ClosestPointToTriangle(trianglePoints, point);
+                    closerPointToFaceList.Add(closestPoint0);
                 }
-
-                // Quad with only one diagonal 
-                /*else if (faceVertices .Count == 4)
-                {
-                    var trianglePoints1 = new Point3[] { faceVertices [0], faceVertices [1], faceVertices [2] };
-                    var trianglePoints4 = new Point3[] { faceVertices [0], faceVertices [2], faceVertices [3] };
-
-                    var ClosestPoint1 = ClosestPointToTriangle(trianglePoints1, point);
-                    var ClosestPoint4 = ClosestPointToTriangle(trianglePoints4, point);
-
-                    var TrianglesCP = new Point3[2] {ClosestPoint1, ClosestPoint4};
-                    Point3 ClosestPoint = Point3.CloudClosestPoint(TrianglesCP, point); 
-
-                    CloserPointToFace_List.Add(ClosestPoint);
-                }*/
-
                 else 
                 {
-                    // Ngon triangulation using the vertices centroid and consecutive vertices to create the triangles 
-                    List<Point3> Points = faceVertices.ConvertAll(v => (Point3)v);
+                    // Ngon triangulation using the vertices' centroid and consecutive vertices to create the triangles 
                     Point3 ngonCentre = Point3.AveragePoint(faceVertices);
-
                     var TrianglesCP = new List<Point3>();
 
                     for (int i = 0; i < faceVertices .Count; i++)
                     {
-                        Point3[] trianglePoints = new Point3[] { ngonCentre, faceVertices [i], faceVertices [(i + 1)% faceVertices .Count] };
+                        Point3[] trianglePoints = new Point3[] { ngonCentre, faceVertices[i], faceVertices[(i + 1)% faceVertices.Count] };
                         Point3 ClosestPointToNgon = ClosestPointToTriangle(trianglePoints, point);
                         TrianglesCP.Add(ClosestPointToNgon);
                     }
                     Point3 ClosestPoint = Point3.CloudClosestPoint(TrianglesCP, point);
-                    CloserPointToFace_List.Add(ClosestPoint);
+                    closerPointToFaceList.Add(ClosestPoint);
                 }
             }
-            Point3 MeshClosestPoint = Point3.CloudClosestPoint(CloserPointToFace_List, point);
-            return MeshClosestPoint;
+            Point3 meshClosestPoint = Point3.CloudClosestPoint(closerPointToFaceList, point);
+            return new Point3(meshClosestPoint);
         }
 
         /// <summary>

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -548,11 +548,11 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// Checks if point is in or out a triangle
+        /// Checks if point is in or out a triangle.
         /// </summary>
         /// <param name="projection">Point to check.</param>
         /// <param name="trianglePoints">Triangle vertices.</param>
-        /// <returns> boolean result (In - True , Out - False) </returns>
+        /// <returns>Boolean result (In - True , Out - False).</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when trianglePoints is not 3 points.</exception>
         private bool IsPointInTriangle(Point3 projection, Point3[] trianglePoints)
         {
@@ -586,7 +586,7 @@ namespace GShark.Geometry
 
 
         /// <summary>
-        /// Finds the closest point to a triangle
+        /// Finds the closest point to a triangle.
         /// </summary>
         /// <param name="trianglePoints">Triangle vertices.</param>
         /// <param name="point">Test point.</param>
@@ -625,7 +625,7 @@ namespace GShark.Geometry
         /// </summary>
         /// <param name="point">Test point.</param>
         /// <returns>Mesh Closest Point.</returns>
-        /// <exception>Method does not work with concave Ngons.</exception>
+        /// <exception>Method does not work with concave Ngon faces.</exception>
         public Point3 ClosestPoint(Point3 point)
         {
             List<MeshVertex> meshVertices = Vertices;
@@ -635,7 +635,7 @@ namespace GShark.Geometry
 
             foreach (MeshFace face in allFaces)
             {
-                // Retrives the Vertices associated with each face
+                // Retrives the vertices associated with each face
                 List<MeshVertex> faceVertices = face.AdjacentVertices();
                 
                 if (faceVertices.Count == 3)

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -607,17 +607,28 @@ namespace GShark.Geometry
             return point.CloudClosestPoint(edgesClosestPoints);
         }
 
+        // Function to find mid point from cloud 
+        private Point3 midPoint(List<Point3> points)
+        {
+            Point3 pointTotSum = Point3.Origin;
+            for (int i = 0; i < points.Count() - 1; i++)
+            {
+                pointTotSum += points[i];
+            }
+            Point3 mid = pointTotSum / points.Count();
+            return mid;
+        }
 
         public Point3 ClosestPoint(Point3 point)
         {
             // Gets vertices and converts them from type "MeshVertex" to "Point3"
             List<MeshVertex> meshVertices = Vertices;
-            List<Point3> verticesPoints = meshVertices.ConvertAll(v => (Point3)v);
+            //List<Point3> verticesPoints = meshVertices.ConvertAll(v => (Point3)v);
 
             // Finds closer vertex to the target point
-            Point3 CloserPointVertex = point.CloudClosestPoint(verticesPoints);
+            //Point3 CloserPointVertex = point.CloudClosestPoint(meshVertices);
             // Finds the equivalent point as a type "MeshVertex" using the index of the Point3 in its equivalent list
-            MeshVertex CloserVertex = meshVertices[verticesPoints.IndexOf(CloserPointVertex)];
+            //MeshVertex CloserVertex = meshVertices[meshVertices.IndexOf(CloserPointVertex)];
 
             // Finds adjiacent faces to the closer vertex
             //System.Collections.Generic.IEnumerable<MeshFace> AdjacentFaces = CloserVertex.AdjacentFaces();
@@ -658,8 +669,29 @@ namespace GShark.Geometry
                 }
                 else 
                 {
-                    //throw new Exception("Ngon detected");
-                    
+                    throw new Exception("Ngon detected");
+                    //Stellate method (from Ngon to triangles) 
+                    List<Point3> GSVerticesPoints = GSVertices.ConvertAll(v => (Point3)v);
+                    Point3 ngonCentre = midPoint(GSVerticesPoints);
+
+                    var TrianglesCP = new List<Point3>();
+
+                    for (int i = 0; i < GSVertices.Count; i++)
+                    {
+                        Point3[] trianglePoints;
+                        if (i== GSVertices.Count - 1)
+                        {
+                            trianglePoints = new Point3[] { ngonCentre, GSVertices[i], GSVertices[0] };
+                        }
+                        else
+                        {
+                            trianglePoints = new Point3[] { ngonCentre, GSVertices[i], GSVertices[i + 1] };
+                        }
+                        Point3 ClosestPointToNgon = ClosestPointToTriangle(trianglePoints, point);
+                        TrianglesCP.Add(ClosestPointToNgon);
+                    }
+                    Point3 ClosestPoint = point.CloudClosestPoint(TrianglesCP);
+                    CloserPointToFace_List.Add(ClosestPoint);
                 }
             }
             Point3 MeshClosestPoint = point.CloudClosestPoint(CloserPointToFace_List);

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -638,7 +638,7 @@ namespace GShark.Geometry
                     Point3 ClosestPoint0 = ClosestPointToTriangle(trianglePoints, point);
                     CloserPointToFace_List.Add(ClosestPoint0);
                 }
-                if (GSVertices.Count == 4)
+                else if (GSVertices.Count == 4)
                 {
                     var trianglePoints1 = new Point3[] { FacePoints[0], FacePoints[1], FacePoints[2] };
                     var trianglePoints2 = new Point3[] { FacePoints[1], FacePoints[2], FacePoints[3] };
@@ -657,16 +657,7 @@ namespace GShark.Geometry
                 }
                 else 
                 {
-                    List<Point3> TrianglesCP = new List<Point3>();
-                    //Point3 ClosestPoint = point.CloudClosestPoint(FacePoints);
-                    for (int i = 0; i < (GSVertices.Count-2); i++)
-                    {
-                        var trianglePoints = new Point3[] { FacePoints[0], FacePoints[i + 1], FacePoints[i + 2] };
-                        Point3 ClosestPointToNgon = ClosestPointToTriangle(trianglePoints, point);
-                        TrianglesCP.Add(ClosestPointToNgon);
-                    }
-                    Point3 ClosestPoint = point.CloudClosestPoint(TrianglesCP);
-                    CloserPointToFace_List.Add(ClosestPoint);
+                    throw new Exception("Ngon detected");
                 }
             }
             Point3 MeshClosestPoint = point.CloudClosestPoint(CloserPointToFace_List);

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -658,8 +658,6 @@ namespace GShark.Geometry
                 else 
                 {
                     throw new Exception("Ngon detected");
-                    // using Rhino as the checking tool the code path will never end up here because Rhino considers Ngons are a collection of triangles and quads 
-                    //trying to keep the definition of Ngon will crash the "Rhino mesh > G Shark mesh method" in the RhinoCommand code
                 }
             }
             Point3 MeshClosestPoint = point.CloudClosestPoint(CloserPointToFace_List);

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -604,14 +604,14 @@ namespace GShark.Geometry
                 Point3 segmentClosestPoint = segment.ClosestPoint(point);
                 edgesClosestPoints.Add(segmentClosestPoint);
             }
-            return point.CloudClosestPoint(edgesClosestPoints);
+            return Point3.CloudClosestPoint(edgesClosestPoints, point);
         }
 
         public Point3 ClosestPoint(Point3 point)
         {
             List<MeshVertex> meshVertices = Vertices;
 
-            //All faces check 
+            // All faces check 
             System.Collections.Generic.IEnumerable<MeshFace> AllFaces = this.Faces;
 
             var CloserPointToFace_List = new List<Point3>();
@@ -619,53 +619,51 @@ namespace GShark.Geometry
             foreach (MeshFace face in AllFaces)
             {
                 // Retrives the Vertices associated with each face
-                List<MeshVertex> GSVertices = face.AdjacentVertices();
+                List<MeshVertex> faceVertices = face.AdjacentVertices();
                 // Converts from MeshVertex to Point3
-                List<Point3> FacePoints = GSVertices.ConvertAll(v => (Point3)v);
+                //List<Point3> faceVertices  = faceVertices .ConvertAll(v => (Point3)v);
 
-                if (GSVertices.Count == 3)
+                if (faceVertices .Count == 3)
                 {
-                    var trianglePoints = new Point3[] { FacePoints[0], FacePoints[1], FacePoints[2] };
+                    var trianglePoints = new Point3[] { faceVertices [0], faceVertices [1], faceVertices [2] };
                     Point3 ClosestPoint0 = ClosestPointToTriangle(trianglePoints, point);
                     CloserPointToFace_List.Add(ClosestPoint0);
                 }
-                else if (GSVertices.Count == 4)
+
+                // Quad with only one diagonal 
+                /*else if (faceVertices .Count == 4)
                 {
-                    var trianglePoints1 = new Point3[] { FacePoints[0], FacePoints[1], FacePoints[2] };
-                    var trianglePoints2 = new Point3[] { FacePoints[1], FacePoints[2], FacePoints[3] };
-                    var trianglePoints3 = new Point3[] { FacePoints[0], FacePoints[1], FacePoints[3] };
-                    var trianglePoints4 = new Point3[] { FacePoints[0], FacePoints[2], FacePoints[3] };
+                    var trianglePoints1 = new Point3[] { faceVertices [0], faceVertices [1], faceVertices [2] };
+                    var trianglePoints4 = new Point3[] { faceVertices [0], faceVertices [2], faceVertices [3] };
 
                     var ClosestPoint1 = ClosestPointToTriangle(trianglePoints1, point);
-                    var ClosestPoint2 = ClosestPointToTriangle(trianglePoints2, point);
-                    var ClosestPoint3 = ClosestPointToTriangle(trianglePoints3, point);
                     var ClosestPoint4 = ClosestPointToTriangle(trianglePoints4, point);
 
-                    var TrianglesCP = new Point3[4] { ClosestPoint1, ClosestPoint2, ClosestPoint3, ClosestPoint4 };
-                    Point3 ClosestPoint = point.CloudClosestPoint(TrianglesCP);
+                    var TrianglesCP = new Point3[2] {ClosestPoint1, ClosestPoint4};
+                    Point3 ClosestPoint = Point3.CloudClosestPoint(TrianglesCP, point); 
 
                     CloserPointToFace_List.Add(ClosestPoint);
-                }
+                }*/
+
                 else 
                 {
-                    //throw new Exception("Ngon detected");
-                    // Stellate method (from Ngon to triangles) 
-                    List<Point3> GSVerticesPoints = GSVertices.ConvertAll(v => (Point3)v);
-                    Point3 ngonCentre = Point3.AveragePoint(GSVerticesPoints);
+                    // Ngon triangulation using the vertices centroid and consecutive vertices to create the triangles 
+                    List<Point3> Points = faceVertices.ConvertAll(v => (Point3)v);
+                    Point3 ngonCentre = Point3.AveragePoint(faceVertices);
 
                     var TrianglesCP = new List<Point3>();
 
-                    for (int i = 0; i < GSVertices.Count; i++)
+                    for (int i = 0; i < faceVertices .Count; i++)
                     {
-                        Point3[] trianglePoints = new Point3[] { ngonCentre, GSVertices[i], GSVertices[(i + 1)% GSVertices.Count] };
+                        Point3[] trianglePoints = new Point3[] { ngonCentre, faceVertices [i], faceVertices [(i + 1)% faceVertices .Count] };
                         Point3 ClosestPointToNgon = ClosestPointToTriangle(trianglePoints, point);
                         TrianglesCP.Add(ClosestPointToNgon);
                     }
-                    Point3 ClosestPoint = point.CloudClosestPoint(TrianglesCP);
+                    Point3 ClosestPoint = Point3.CloudClosestPoint(TrianglesCP, point);
                     CloserPointToFace_List.Add(ClosestPoint);
                 }
             }
-            Point3 MeshClosestPoint = point.CloudClosestPoint(CloserPointToFace_List);
+            Point3 MeshClosestPoint = Point3.CloudClosestPoint(CloserPointToFace_List, point);
             return MeshClosestPoint;
         }
 

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -625,7 +625,7 @@ namespace GShark.Geometry
         /// </summary>
         /// <param name="point">Test point.</param>
         /// <returns>Mesh Closest Point.</returns>
-        /// <exception>Method does not work with concave Ngon faces.</exception>
+        /// <remark>Method might not work with concave Ngon faces.</remark>
         public Point3 ClosestPoint(Point3 point)
         {
             List<MeshVertex> meshVertices = Vertices;

--- a/src/GShark/Geometry/Mesh.cs
+++ b/src/GShark/Geometry/Mesh.cs
@@ -611,7 +611,7 @@ namespace GShark.Geometry
         private Point3 midPoint(List<Point3> points)
         {
             Point3 pointTotSum = Point3.Origin;
-            for (int i = 0; i < points.Count() - 1; i++)
+            for (int i = 0; i < points.Count(); i++)
             {
                 pointTotSum += points[i];
             }
@@ -669,7 +669,7 @@ namespace GShark.Geometry
                 }
                 else 
                 {
-                    throw new Exception("Ngon detected");
+                    //throw new Exception("Ngon detected");
                     //Stellate method (from Ngon to triangles) 
                     List<Point3> GSVerticesPoints = GSVertices.ConvertAll(v => (Point3)v);
                     Point3 ngonCentre = midPoint(GSVerticesPoints);

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -718,7 +718,7 @@ namespace GShark.Geometry
             return inside ? 1 : -1;
         }
 
-        // Function to find mid point from cloud 
+        /* Function to find mid point from cloud 
         private Point3 midPoint(List<Point3> points)
         {
             Point3 pointTotSum = Point3.Origin;
@@ -728,7 +728,7 @@ namespace GShark.Geometry
             }
             Point3 mid = pointTotSum / points.Count();
             return mid;
-        }
+        }*/
 
         // Function that finds point in a cloud of points to a target point
         public Point3 CloudClosestPoint(IEnumerable<Point3> cloud)

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -720,25 +720,25 @@ namespace GShark.Geometry
 
 
         // Function to find mid point from cloud 
-        public static Point3 AveragePoint(List<Point3> points)
+        public static Point3 AveragePoint (IEnumerable<Point3> points)
         {
             Point3 pointTotSum = Point3.Origin;
             for (int i = 0; i < points.Count(); i++)
             {
-                pointTotSum += points[i];
+                pointTotSum += points [i];
             }
             Point3 mid = pointTotSum / points.Count();
             return mid;
         }
 
         // Function that finds point in a cloud of points to a target point
-        public Point3 CloudClosestPoint(IEnumerable<Point3> cloud)
+        public static Point3  CloudClosestPoint  (IEnumerable<Point3> cloud, Point3 targetPoint)
         {
             double minDistance = double.MaxValue;
             Point3 closestPoint = new Point3();
             foreach (Point3 point in cloud)
             {
-                double distanceToTarget = point.DistanceTo(this);
+                double distanceToTarget = point.DistanceTo(targetPoint);
                 if (distanceToTarget < minDistance)
                 {
                     minDistance = distanceToTarget;

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -717,7 +717,26 @@ namespace GShark.Geometry
             }
             return inside ? 1 : -1;
         }
-        
+
+
+
+        //Function that finds point in a cloud of points to a target point
+        public Point3 CloudClosestPoint(List<Point3> cloud)
+        {
+            double Min_list = double.MaxValue;
+            Point3 ClosestPoint = new Point3();
+            foreach (Point3 point in cloud)
+            {
+                double DistanceToTarget = point.DistanceTo(this);
+                if (DistanceToTarget < Min_list)
+                {
+                    Min_list = DistanceToTarget;
+                    ClosestPoint = point;
+                }
+            }
+            return ClosestPoint;
+        }
+
     }
 }
 

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -718,17 +718,18 @@ namespace GShark.Geometry
             return inside ? 1 : -1;
         }
 
-        /* Function to find mid point from cloud 
-        private Point3 midPoint(List<Point3> points)
+
+        // Function to find mid point from cloud 
+        public static Point3 AveragePoint(List<Point3> points)
         {
             Point3 pointTotSum = Point3.Origin;
-            for (int i = 0; i < points.Count() - 1; i++)
+            for (int i = 0; i < points.Count(); i++)
             {
                 pointTotSum += points[i];
             }
             Point3 mid = pointTotSum / points.Count();
             return mid;
-        }*/
+        }
 
         // Function that finds point in a cloud of points to a target point
         public Point3 CloudClosestPoint(IEnumerable<Point3> cloud)

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -720,21 +720,21 @@ namespace GShark.Geometry
 
 
 
-        //Function that finds point in a cloud of points to a target point
-        public Point3 CloudClosestPoint(List<Point3> cloud)
+        // Function that finds point in a cloud of points to a target point
+        public Point3 CloudClosestPoint(IEnumerable<Point3> cloud)
         {
-            double Min_list = double.MaxValue;
-            Point3 ClosestPoint = new Point3();
+            double minDistance = double.MaxValue;
+            Point3 closestPoint = new Point3();
             foreach (Point3 point in cloud)
             {
-                double DistanceToTarget = point.DistanceTo(this);
-                if (DistanceToTarget < Min_list)
+                double distanceToTarget = point.DistanceTo(this);
+                if (distanceToTarget < minDistance)
                 {
-                    Min_list = DistanceToTarget;
-                    ClosestPoint = point;
+                    minDistance = distanceToTarget;
+                    closestPoint = point;
                 }
             }
-            return ClosestPoint;
+            return closestPoint;
         }
 
     }

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -740,6 +740,7 @@ namespace GShark.Geometry
         /// <param name="cloud">Collection of points from which the closest is chosen.</param>
         /// <param name="testPoint"></param>
         /// <returns>Closest from from the cloud of points.</returns>
+        /// <remark>Returns the same object within the cloud without copying it.</remark>
         public static Point3 CloudClosestPoint (IEnumerable<Point3> cloud, Point3 testPoint)
         {
             double minDistance = double.MaxValue;

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -718,27 +718,35 @@ namespace GShark.Geometry
             return inside ? 1 : -1;
         }
 
-
-        // Function to find mid point from cloud 
+        /// <summary>
+        /// Finds mid point from a cloud of points.  
+        /// </summary>
+        /// <param name="points"></param>
+        /// <returns>The average point.</returns>
         public static Point3 AveragePoint (IEnumerable<Point3> points)
         {
             Point3 pointTotSum = Point3.Origin;
-            for (int i = 0; i < points.Count(); i++)
+            foreach (Point3 point in points)
             {
-                pointTotSum += points [i];
+                pointTotSum += point;
             }
             Point3 mid = pointTotSum / points.Count();
             return mid;
         }
 
-        // Function that finds point in a cloud of points to a target point
-        public static Point3  CloudClosestPoint  (IEnumerable<Point3> cloud, Point3 targetPoint)
+        /// <summary>
+        /// Finds closest point to a test point from a cloud of points.
+        /// </summary>
+        /// <param name="cloud">Collection of points from which the closest is chosen.</param>
+        /// <param name="testPoint"></param>
+        /// <returns>Closest from from the cloud of points.</returns>
+        public static Point3 CloudClosestPoint (IEnumerable<Point3> cloud, Point3 testPoint)
         {
             double minDistance = double.MaxValue;
             Point3 closestPoint = new Point3();
             foreach (Point3 point in cloud)
             {
-                double distanceToTarget = point.DistanceTo(targetPoint);
+                double distanceToTarget = point.DistanceTo(testPoint);
                 if (distanceToTarget < minDistance)
                 {
                     minDistance = distanceToTarget;

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -719,7 +719,7 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// Finds mid point from a cloud of points.  
+        /// Finds average point from a cloud of points.  
         /// </summary>
         /// <param name="points"></param>
         /// <returns>The average point.</returns>
@@ -730,16 +730,16 @@ namespace GShark.Geometry
             {
                 pointTotSum += point;
             }
-            Point3 mid = pointTotSum / points.Count();
-            return mid;
+            Point3 average = pointTotSum / points.Count();
+            return average;
         }
 
         /// <summary>
         /// Finds closest point to a test point from a cloud of points.
         /// </summary>
-        /// <param name="cloud">Collection of points from which the closest is chosen.</param>
+        /// <param name="cloud">Cloud of points from which the closest is chosen.</param>
         /// <param name="testPoint"></param>
-        /// <returns>Closest from from the cloud of points.</returns>
+        /// <returns>Closest point.</returns>
         /// <remark>Returns the same object within the cloud without copying it.</remark>
         public static Point3 CloudClosestPoint (IEnumerable<Point3> cloud, Point3 testPoint)
         {

--- a/src/GShark/Geometry/Point3.cs
+++ b/src/GShark/Geometry/Point3.cs
@@ -718,7 +718,17 @@ namespace GShark.Geometry
             return inside ? 1 : -1;
         }
 
-
+        // Function to find mid point from cloud 
+        private Point3 midPoint(List<Point3> points)
+        {
+            Point3 pointTotSum = Point3.Origin;
+            for (int i = 0; i < points.Count() - 1; i++)
+            {
+                pointTotSum += points[i];
+            }
+            Point3 mid = pointTotSum / points.Count();
+            return mid;
+        }
 
         // Function that finds point in a cloud of points to a target point
         public Point3 CloudClosestPoint(IEnumerable<Point3> cloud)


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

### Description

This PR adds a ClosestPoint() implementation for meshes. The method takes a mesh and a test point and returns the closest point to the test point on the mesh. The algorithm finds the closest point to all the faces, then the absolute closest. This point can be either on a mesh vertex, mesh edge, or inside a mesh face. The method can be used with triangle meshes, quad meshes, and Ngon meshes. Any Ngons faces are triangulated using vertices' centroid and consecutive vertices. Quads are treated as Ngons. I did not work on the tests yet, I'd like some feedback first.

### Related Tickets & Documents

Please use this format link issue numbers: Fixes #416
https://github.com/GSharker/G-Shark/issues/416#issue-1736250025

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 docs
- [x] 🙅 no documentation needed
